### PR TITLE
Start collection of basic data types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,116 @@
+name: rustls
+
+permissions:
+  contents: read
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 21 * * *'
+
+jobs:
+  build:
+    name: Build + test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # test a bunch of toolchains on ubuntu
+        rust:
+          - stable
+          - beta
+          - nightly
+        os: [ubuntu-20.04]
+        # but only stable on macos/windows (slower platforms)
+        include:
+          - os: macos-latest
+            rust: stable
+          - os: windows-latest
+            rust: stable
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: cargo test (debug; default features)
+        run: cargo test
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: cargo test (debug; all features)
+        run: cargo test --all-features
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: cargo test (debug; no default features; no run)
+        run: cargo test --no-default-features
+        env:
+          RUST_BACKTRACE: 1
+
+  msrv:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.60"
+
+      - run: cargo check --lib --all-features
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy --all-features -- --deny warnings
+
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,16 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"
+description = "Shared types for the rustls PKI ecosystem"
+documentation = "https://docs.rs/rustls-pki-types"
+homepage = "https://github.com/rustls/pki-types"
+repository = "https://github.com/rustls/pki-types"
+categories = ["network-programming", "data-structures", "cryptography"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["alloc"]
+alloc = []
 
-[dependencies]
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "rustls-pki-types"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.60"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2023 Dirkjan Ochtman
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2023 Dirkjan Ochtman <dirkjan@ochtman.nl>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# rustls-pki-types
+
+[![Build Status](https://github.com/rustls/pki-types/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/rustls/pki-types/actions/workflows/ci.yml?query=branch%3Amain)
+[![Documentation](https://docs.rs/rustls-pki-types/badge.svg)](https://docs.rs/rustls-pki-types/)
+[![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/MCSB76RU96)
+
+This crate provides types for representing X.509 certificates, keys and other types as commonly
+used in the rustls ecosystem. It is intended to be used by crates that need to work with such X.509
+types, such as [rustls](https://crates.io/crates/rustls),
+[rustls-webpki](https://crates.io/crates/rustls-webpki),
+[rustls-pemfile](https://crates.io/crates/rustls-pemfile), and others.
+
+Some of these crates used to define their own trivial wrappers around DER-encoded bytes.
+However, in order to avoid inconvenient dependency edges, these were all disconnected. By
+using a common low-level crate of types with long-term stable API, we hope to avoid the
+downsides of unnecessary dependency edges while providing interoperability between crates.
+
+## Features
+
+- Interoperability between different crates in the rustls ecosystem
+- Long-term stable API
+- No dependencies
+- Support for `no_std` contexts, with optional support for `alloc`
+
+## DER and PEM
+
+Many of the types defined in this crate represent DER-encoded data. DER is a binary encoding of
+the ASN.1 format commonly used in web PKI specifications. It is a binary encoding, so it is
+relatively compact when stored in memory. However, as a binary format, it is not very easy to
+work with for humans and in contexts where binary data is inconvenient. For this reason,
+many tools and protocols use a ASCII-based encoding of DER, called PEM. In addition to the
+base64-encoded DER, PEM objects are delimited by header and footer lines which indicate the type
+of object contained in the PEM blob.
+
+The [rustls-pemfile](https://docs.rs/rustls-pemfile) crate can be used to parse PEM files.
+
+## Creating new certificates and keys
+
+This crate does not provide any functionality for creating new certificates or keys. However,
+the [rcgen](https://docs.rs/rcgen) crate can be used to create new certificates and keys.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,351 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+//! This crate provides types for representing X.509 certificates, keys and other types as
+//! commonly used in the rustls ecosystem. It is intended to be used by crates that need to work
+//! with such X.509 types, such as [rustls](https://crates.io/crates/rustls),
+//! [rustls-webpki](https://crates.io/crates/rustls-webpki),
+//! [rustls-pemfile](https://crates.io/crates/rustls-pemfile), and others.
+//!
+//! Some of these crates used to define their own trivial wrappers around DER-encoded bytes.
+//! However, in order to avoid inconvenient dependency edges, these were all disconnected. By
+//! using a common low-level crate of types with long-term stable API, we hope to avoid the
+//! downsides of unnecessary dependency edges while providing good interoperability between crates.
+//!
+//! ## DER and PEM
+//!
+//! Many of the types defined in this crate represent DER-encoded data. DER is a binary encoding of
+//! the ASN.1 format commonly used in web PKI specifications. It is a binary encoding, so it is
+//! relatively compact when stored in memory. However, as a binary format, it is not very easy to
+//! work with for humans and in contexts where binary data is inconvenient. For this reason,
+//! many tools and protocols use a ASCII-based encoding of DER, called PEM. In addition to the
+//! base64-encoded DER, PEM objects are delimited by header and footer lines which indicate the type
+//! of object contained in the PEM blob.
+//!
+//! The [rustls-pemfile](https://docs.rs/rustls-pemfile) crate can be used to parse PEM files.
+//!
+//! ## Creating new certificates and keys
+//!
+//! This crate does not provide any functionality for creating new certificates or keys. However,
+//! the [rcgen](https://docs.rs/rcgen) crate can be used to create new certificates and keys.
+
+#![no_std]
+#![warn(unreachable_pub, clippy::use_self)]
+#![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::Deref;
+
+/// A DER-encoded X.509 private key, in one of several formats
+///
+/// See variant inner types for more detailed information.
+#[non_exhaustive]
+#[derive(Debug, PartialEq)]
+pub enum PrivateKeyDer<'a> {
+    /// An RSA private key
+    Pkcs1(PrivatePkcs1KeyDer<'a>),
+    /// A Sec1 private key
+    Sec1(PrivateSec1KeyDer<'a>),
+    /// A PKCS#8 private key
+    Pkcs8(PrivatePkcs8KeyDer<'a>),
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+impl<'a> PrivateKeyDer<'a> {
+    /// Yield the DER-encoded bytes of the private key
+    pub fn secret_der(&self) -> &[u8] {
+        match self {
+            PrivateKeyDer::Pkcs1(key) => key.secret_pkcs1_der(),
+            PrivateKeyDer::Sec1(key) => key.secret_sec1_der(),
+            PrivateKeyDer::Pkcs8(key) => key.secret_pkcs8_der(),
+        }
     }
+}
+
+impl<'a> From<PrivatePkcs1KeyDer<'a>> for PrivateKeyDer<'a> {
+    fn from(key: PrivatePkcs1KeyDer<'a>) -> Self {
+        Self::Pkcs1(key)
+    }
+}
+
+impl<'a> From<PrivateSec1KeyDer<'a>> for PrivateKeyDer<'a> {
+    fn from(key: PrivateSec1KeyDer<'a>) -> Self {
+        Self::Sec1(key)
+    }
+}
+
+impl<'a> From<PrivatePkcs8KeyDer<'a>> for PrivateKeyDer<'a> {
+    fn from(key: PrivatePkcs8KeyDer<'a>) -> Self {
+        Self::Pkcs8(key)
+    }
+}
+
+/// A DER-encoded plaintext RSA private key; as specified in PKCS#1/RFC 3447
+///
+/// RSA private keys are identified in PEM context as `RSA PRIVATE KEY` and when stored in a
+/// file usually use a `.pem` or `.key` extension. For more on PEM files, refer to the crate
+/// documentation.
+#[derive(PartialEq)]
+pub struct PrivatePkcs1KeyDer<'a>(Der<'a>);
+
+impl PrivatePkcs1KeyDer<'_> {
+    /// Yield the DER-encoded bytes of the private key
+    pub fn secret_pkcs1_der(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for PrivatePkcs1KeyDer<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(Der(DerInner::Borrowed(slice)))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for PrivatePkcs1KeyDer<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Der(DerInner::Owned(vec)))
+    }
+}
+
+impl fmt::Debug for PrivatePkcs1KeyDer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PrivatePkcs1KeyDer")
+            .field(&"[secret key elided]")
+            .finish()
+    }
+}
+
+/// A Sec1-encoded plaintext private key; as specified in RFC 5915
+///
+/// Sec1 private keys are identified in PEM context as `EC PRIVATE KEY` and when stored in a
+/// file usually use a `.pem` or `.key` extension. For more on PEM files, refer to the crate
+/// documentation.
+#[derive(PartialEq)]
+pub struct PrivateSec1KeyDer<'a>(Der<'a>);
+
+impl PrivateSec1KeyDer<'_> {
+    /// Yield the DER-encoded bytes of the private key
+    pub fn secret_sec1_der(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for PrivateSec1KeyDer<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(Der(DerInner::Borrowed(slice)))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for PrivateSec1KeyDer<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Der(DerInner::Owned(vec)))
+    }
+}
+
+impl fmt::Debug for PrivateSec1KeyDer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PrivatePkcs1KeyDer")
+            .field(&"[secret key elided]")
+            .finish()
+    }
+}
+
+/// A DER-encoded plaintext private key; as specified in PKCS#8/RFC 5958
+///
+/// PKCS#8 private keys are identified in PEM context as `PRIVATE KEY` and when stored in a
+/// file usually use a `.pem` or `.key` extension. For more on PEM files, refer to the crate
+/// documentation.
+#[derive(PartialEq)]
+pub struct PrivatePkcs8KeyDer<'a>(Der<'a>);
+
+impl PrivatePkcs8KeyDer<'_> {
+    /// Yield the DER-encoded bytes of the private key
+    pub fn secret_pkcs8_der(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for PrivatePkcs8KeyDer<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(Der(DerInner::Borrowed(slice)))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for PrivatePkcs8KeyDer<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Der(DerInner::Owned(vec)))
+    }
+}
+
+impl fmt::Debug for PrivatePkcs8KeyDer<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PrivatePkcs1KeyDer")
+            .field(&"[secret key elided]")
+            .finish()
+    }
+}
+
+/// A trust anchor (a.k.a. root CA)
+///
+/// Traditionally, certificate verification libraries have represented trust anchors as full X.509
+/// root certificates. However, those certificates contain a lot more data than is needed for
+/// verifying certificates. The [`TrustAnchor`] representation allows an application to store
+/// just the essential elements of trust anchors.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrustAnchor<'a> {
+    /// Value of the `subject` field of the trust anchor
+    pub subject: Der<'a>,
+    /// Value of the `subjectPublicKeyInfo` field of the trust anchor
+    pub subject_public_key_info: Der<'a>,
+    /// Value of DER-encoded `NameConstraints`, containing name constraints to the trust anchor, if any
+    pub name_constraints: Option<Der<'a>>,
+}
+
+impl TrustAnchor<'_> {
+    /// Yield a `'static` lifetime of the `TrustAnchor` by allocating owned `Der` variants
+    #[cfg(feature = "alloc")]
+    pub fn to_owned(&self) -> TrustAnchor<'static> {
+        use alloc::borrow::ToOwned;
+        TrustAnchor {
+            subject: self.subject.as_ref().to_owned().into(),
+            subject_public_key_info: self.subject_public_key_info.as_ref().to_owned().into(),
+            name_constraints: self
+                .name_constraints
+                .as_ref()
+                .map(|nc| nc.as_ref().to_owned().into()),
+        }
+    }
+}
+
+/// A Certificate Revocation List; as specified in RFC 5280
+///
+/// Certificate revocation lists are identified in PEM context as `X509 CRL` and when stored in a
+/// file usually use a `.crl` extension. For more on PEM files, refer to the crate documentation.
+#[derive(Debug, PartialEq)]
+pub struct CertificateRevocationListDer<'a>(Der<'a>);
+
+impl AsRef<[u8]> for CertificateRevocationListDer<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Deref for CertificateRevocationListDer<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for CertificateRevocationListDer<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(Der::from(slice))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for CertificateRevocationListDer<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Der::from(vec))
+    }
+}
+
+/// A DER-encoded X.509 certificate; as specified in RFC 5280
+///
+/// Certificates are identified in PEM context as `CERTIFICATE` and when stored in a
+/// file usually use a `.pem`, `.cer` or `.crt` extension. For more on PEM files, refer to the
+/// crate documentation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CertificateDer<'a>(Der<'a>);
+
+impl AsRef<[u8]> for CertificateDer<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Deref for CertificateDer<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for CertificateDer<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(Der::from(slice))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for CertificateDer<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Der::from(vec))
+    }
+}
+
+/// DER-encoded data, either owned or borrowed
+///
+/// This wrapper type is used to represent DER-encoded data in a way that is agnostic to whether
+/// the data is owned (by a `Vec<u8>`) or borrowed (by a `&[u8]`). Support for the owned
+/// variant is only available when the `alloc` feature is enabled.
+#[derive(Clone, PartialEq)]
+pub struct Der<'a>(DerInner<'a>);
+
+impl<'a> Der<'a> {
+    /// A const constructor to create a `Der` from a borrowed slice
+    pub const fn from_slice(der: &'a [u8]) -> Self {
+        Self(DerInner::Borrowed(der))
+    }
+}
+
+impl AsRef<[u8]> for Der<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            #[cfg(feature = "alloc")]
+            DerInner::Owned(vec) => vec.as_ref(),
+            DerInner::Borrowed(slice) => slice,
+        }
+    }
+}
+
+impl Deref for Der<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for Der<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(DerInner::Borrowed(slice))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<Vec<u8>> for Der<'static> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(DerInner::Owned(vec))
+    }
+}
+
+impl fmt::Debug for Der<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Der").field(&self.as_ref()).finish()
+    }
+}
+
+#[derive(Clone, PartialEq)]
+enum DerInner<'a> {
+    #[cfg(feature = "alloc")]
+    Owned(Vec<u8>),
+    Borrowed(&'a [u8]),
 }


### PR DESCRIPTION
The idea here is to share a long-term stable (as in, no semver-breaking updates) collection of types that can be used as shared context between rustls, webpki, webpki-roots, rustls-native-certs and rustls-pemfile. Right now, there are a number of pain points where the conversion from rustls-native-certs to rustls `OwnedTrustAnchor` is pretty manual. 

Some of these crates (like rustls-native-certs) previously had a dependency on rustls to share its basic `Certificate` and `PrivateKey` dependencies, however rustls evolves much more quickly than rustls-native-certs so that also generated some unwanted churn.

The API here is optimized for long-term stability and doesn't need `std` so it can be used with webpki in `no_std` mode. Its dependency on `alloc` is optional. We also use an inner `Cow`-like type to abstract over slices and `Vec`s with a lifetime, so that a `TrustAnchor` using `&'static [u8]` field values could be used directly in a rustls verifier.

There has been some discussion of this in rustls issues/PRs but I can't find it now. At the time, Brian was not a fan of this idea.

Related PRs:

* https://github.com/rustls/pemfile/pull/24
* https://github.com/rustls/webpki/pull/147
* https://github.com/rustls/webpki-roots/pull/45 (depends on webpki)
* https://github.com/rustls/rustls/pull/1432 (depends on webpki and webpki-roots)