### PR TITLE
Migrate signature verification trait to here

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,72 @@ impl<'a> From<Vec<u8>> for CertificateDer<'a> {
     }
 }
 
+/// A DER encoding of the PKIX AlgorithmIdentifier type:
+///
+/// ```ASN.1
+/// AlgorithmIdentifier  ::=  SEQUENCE  {
+///     algorithm               OBJECT IDENTIFIER,
+///     parameters              ANY DEFINED BY algorithm OPTIONAL  }
+///                                -- contains a value of the type
+///                                -- registered for use with the
+///                                -- algorithm object identifier value
+/// ```
+/// (from <https://www.rfc-editor.org/rfc/rfc5280#section-4.1.1.2>)
+///
+/// The outer sequence encoding is *not included*, so this is the DER encoding
+/// of an OID for `algorithm` plus the `parameters` value.
+///
+/// For example, this is the `rsaEncryption` algorithm:
+///
+/// ```
+/// let rsa_encryption = rustls_pki_types::AlgorithmIdentifier::from_slice(
+///     &[
+///         // algorithm: 1.2.840.113549.1.1.1
+///         0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01,
+///         // parameters: NULL
+///         0x05, 0x00
+///     ]
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct AlgorithmIdentifier<'a>(Der<'a>);
+
+impl<'a> AlgorithmIdentifier<'a> {
+    /// Makes a new `AlgorithmIdentifier` from a static octet slice.
+    ///
+    /// This does not validate the contents of the slice.
+    pub const fn from_slice(bytes: &'a [u8]) -> Self {
+        Self(Der::from_slice(bytes))
+    }
+}
+
+impl AsRef<[u8]> for AlgorithmIdentifier<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Deref for AlgorithmIdentifier<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for AlgorithmIdentifier<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(Der::from(slice))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for AlgorithmIdentifier<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Der::from(vec))
+    }
+}
+
 /// DER-encoded data, either owned or borrowed
 ///
 /// This wrapper type is used to represent DER-encoded data in a way that is agnostic to whether

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,53 @@ impl<'a> From<Vec<u8>> for CertificateDer<'a> {
     }
 }
 
+/// An abstract signature verification algorithm.
+///
+/// One of these is needed per supported pair of public key type (identified
+/// with `public_key_alg_id()`) and `signatureAlgorithm` (identified with
+/// `signature_alg_id()`).  Note that both of these `AlgorithmIdentifier`s include
+/// the parameters encoding, so separate `SignatureVerificationAlgorithm`s are needed
+/// for each possible public key or signature parameters.
+pub trait SignatureVerificationAlgorithm: Send + Sync {
+    /// Verify a signature.
+    ///
+    /// `public_key` is the `subjectPublicKey` value from a `SubjectPublicKeyInfo` encoding
+    /// and is untrusted.  The key's `subjectPublicKeyInfo` matches the [`AlgorithmIdentifier`]
+    /// returned by `public_key_alg_id()`.
+    ///
+    /// `message` is the data over which the signature was allegedly computed.
+    /// It is not hashed; implementations of this trait function must do hashing
+    /// if that is required by the algorithm they implement.
+    ///
+    /// `signature` is the signature allegedly over `message`.
+    ///
+    /// Return `Ok(())` only if `signature` is a valid signature on `message`.
+    ///
+    /// Return `Err(InvalidSignature)` if the signature is invalid, including if the `public_key`
+    /// encoding is invalid.  There is no need or opportunity to produce errors
+    /// that are more specific than this.
+    fn verify_signature(
+        &self,
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), InvalidSignature>;
+
+    /// Return the `AlgorithmIdentifier` that must equal a public key's
+    /// `subjectPublicKeyInfo` value for this `SignatureVerificationAlgorithm`
+    /// to be used for signature verification.
+    fn public_key_alg_id(&self) -> AlgorithmIdentifier;
+
+    /// Return the `AlgorithmIdentifier` that must equal the `signatureAlgorithm` value
+    /// on the data to be verified for this `SignatureVerificationAlgorithm` to be used
+    /// for signature verification.
+    fn signature_alg_id(&self) -> AlgorithmIdentifier;
+}
+
+/// A detail-less error when a signature is not valid.
+#[derive(Debug, Copy, Clone)]
+pub struct InvalidSignature;
+
 /// A DER encoding of the PKIX AlgorithmIdentifier type:
 ///
 /// ```ASN.1


### PR DESCRIPTION
The goal of this is that downstream crates can implement and pass around this trait and associated types without taking a dependency on a webpki version.

This seems necessary to avoid changes like https://github.com/rustls/rustls/pull/1405/commits/7462764643e62acc763eb51a6bbbf305d5cfa51c exposing webpki types in rustls's public API.

This is not a direct lift-and-shift, the types have changed for consistency with others here, eg `AlgorithmIdentifier` reuses `Der`.