### PR TITLE
add CertificateDer::into_owned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,14 @@ impl<'a> From<Vec<u8>> for CertificateDer<'a> {
     }
 }
 
+impl CertificateDer<'_> {
+    /// Converts this certificate into its owned variant, unfreezing borrowed content (if any)
+    #[cfg(feature = "alloc")]
+    pub fn into_owned(self) -> CertificateDer<'static> {
+        CertificateDer(Der(self.0 .0.into_owned()))
+    }
+}
+
 /// An abstract signature verification algorithm.
 ///
 /// One of these is needed per supported pair of public key type (identified
@@ -490,4 +498,14 @@ enum DerInner<'a> {
     #[cfg(feature = "alloc")]
     Owned(Vec<u8>),
     Borrowed(&'a [u8]),
+}
+
+#[cfg(feature = "alloc")]
+impl DerInner<'_> {
+    fn into_owned(self) -> DerInner<'static> {
+        DerInner::Owned(match self {
+            Self::Owned(vec) => vec,
+            Self::Borrowed(slice) => slice.to_vec(),
+        })
+    }
 }


### PR DESCRIPTION
helps with the performance improvements in rustls/rustls#1597 as it's not possible to do this efficiently in the `Owned` case using only the public API of `CertificateDer`