### PR TITLE
server_name: offer ServerName::to_str w/ alloc/std features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Downstream crates may want to represent a `ServerName` as a `String` or `&str`, e.g. for passing through a `ffi` boundary to external code (for example, [in `rustls-ffi`](https://github.com/rustls/rustls-ffi/blob/a26a3d4ad6cbc13670b6ddbe924db075540c92ac/src/client.rs#L263-L267), or in [`rustls-platform-verifier`](https://github.com/rustls/rustls-platform-verifier/blob/e4194174f2b4b235ed13fc057ce89b19894321e6/src/verification/android.rs#L276-L283)).

This commit implements support for converting a `pki_types::IpAddr` to a `std::net::IpAddr` (to use the `to_string` impl), and adds a `ServerName::to_str` that can return a `Cow<'_, str>` for a `DnsName` or an `IpAddr`.