### PR TITLE
lib: fix clippy warning, cargo fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,7 +537,7 @@ fn hex<'a>(f: &mut fmt::Formatter<'_>, payload: impl IntoIterator<Item = &'a u8>
     Ok(())
 }
 
-#[cfg(feature = "std")]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
 

--- a/tests/server_name.rs
+++ b/tests/server_name.rs
@@ -54,8 +54,6 @@ fn test_alloc_server_name_traits() {
     );
     assert_ne!(
         a,
-        ServerName::try_from(&b"example.co"[..])
-            .unwrap()
-            .to_owned()
+        ServerName::try_from(&b"example.co"[..]).unwrap().to_owned()
     );
 }


### PR DESCRIPTION
The GitHub actions workflows for this repo had been deactivated from inactivity.  I re-enabled them now and updated the branch protection rule for `main` to require each check pass. Doing so caught a small clippy finding I accidentally introduced in https://github.com/rustls/pki-types/pull/13 It's also flagging the `cargo fmt` deviation that I noticed and fixed in https://github.com/rustls/pki-types/pull/14. This branch fixes both.