### PR TITLE
Allow constructing ServerName from String

### DIFF
--- a/src/server_name.rs
+++ b/src/server_name.rs
@@ -91,14 +91,35 @@ impl<'a> TryFrom<&'a str> for ServerName<'a> {
     fn try_from(s: &'a str) -> Result<Self, Self::Error> {
         match DnsName::try_from(s) {
             Ok(dns) => Ok(Self::DnsName(dns)),
-            #[cfg(feature = "std")]
-            Err(InvalidDnsNameError) => match IpAddr::try_from(s) {
-                Ok(ip) => Ok(Self::IpAddress(ip)),
-                Err(_) => Err(InvalidDnsNameError),
-            },
-            #[cfg(not(feature = "std"))]
-            Err(InvalidDnsNameError) => Err(InvalidDnsNameError),
+            Err(_) => Self::try_from_ip_address(s),
         }
+    }
+}
+
+#[cfg(feature = "alloc")]
+/// Attempt to make a ServerName from a string by parsing as a DNS name or IP address.
+impl TryFrom<String> for ServerName<'static> {
+    type Error = InvalidDnsNameError;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match DnsName::try_from(s.clone()) {
+            Ok(dns) => Ok(Self::DnsName(dns)),
+            Err(_) => Self::try_from_ip_address(s.as_str()),
+        }
+    }
+}
+
+impl<'a> ServerName<'a> {
+    #[cfg(feature = "std")]
+    fn try_from_ip_address(s: &str) -> Result<Self, InvalidDnsNameError> {
+        match IpAddr::try_from(s) {
+            Ok(ip) => Ok(Self::IpAddress(ip)),
+            Err(_) => Err(InvalidDnsNameError),
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn try_from_ip_address(_s: &str) -> Result<Self, InvalidDnsNameError> {
+        Err(InvalidDnsNameError)
     }
 }
 


### PR DESCRIPTION
Split the common part out of TryFrom<&str> and allow constructing a ServerName<'static> from a String like we do for DnsName when alloc feature is enabled.

This is useful when the domain name we want to connect to comes from an environmental source