### PR TITLE
server_name: demonstrate using ServerName::to_owned

### DIFF
--- a/src/server_name.rs
+++ b/src/server_name.rs
@@ -29,6 +29,15 @@ use std::error::Error as StdError;
 /// let x = "example.com".try_into().expect("invalid DNS name");
 /// # let _: ServerName = x;
 /// ```
+///
+/// If you require an owned `ServerName` with a `'static` lifetime and have enabled the `alloc`
+/// feature, use [`ServerName::to_owned`]:
+///
+/// ```
+/// # use rustls_pki_types::ServerName;
+/// let my_servername = "example.com".to_string();
+/// ServerName::try_from(my_servername.as_str()).expect("invalid DNS name").to_owned();
+/// ```
 #[non_exhaustive]
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub enum ServerName<'a> {


### PR DESCRIPTION
It seems to be a common source of confusion (https://github.com/rustls/pki-types/pull/19, https://github.com/rustls/tokio-rustls/issues/35) that it's possible to construct an owned `ServerName` from an owned `String` using the existing API and `ServerName::to_owned`. This commit adds an explicit example demonstrating this capability to help make it more discoverable.