### PR TITLE
Document multiple available paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,9 @@ impl<'a> From<Vec<u8>> for CertificateRevocationListDer<'a> {
 /// Certificates are identified in PEM context as `CERTIFICATE` and when stored in a
 /// file usually use a `.pem`, `.cer` or `.crt` extension. For more on PEM files, refer to the
 /// crate documentation.
+///
+/// This type is available as either `rustls_pki_types::CertificateDer` or re-exported as
+/// `rustls::pki_types::CertificateDer`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CertificateDer<'a>(Der<'a>);
 


### PR DESCRIPTION
In https://github.com/rustls/rustls/issues/1662 I raised the issue that it's confusing when seemingly-identical types appear under different paths in different crates, because there's no way for a user to confirm they are in fact identical, compatible types (short of reading the source).

Here's one attempt to solve that: in pki-types, we can document both main paths that an item is available. That documentation line will show up in both pki-types and rustls docs, so there's a signpost no matter which way a reader came to the documentation. Note that I couldn't use intra-doc links because pki-types doesn't depend on rustls.

I've only updated on item so far. I'm happy to do them all (or write a derive macro), but I wanted to get feedback on the concept first.