### PR TITLE
Allow `SignatureVerificationAlgorithm` to state FIPS status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,6 +387,11 @@ pub trait SignatureVerificationAlgorithm: Send + Sync + fmt::Debug {
     /// on the data to be verified for this `SignatureVerificationAlgorithm` to be used
     /// for signature verification.
     fn signature_alg_id(&self) -> AlgorithmIdentifier;
+
+    /// Return `true` if this is backed by a FIPS-approved implementation.
+    fn fips(&self) -> bool {
+        false
+    }
 }
 
 /// A detail-less error when a signature is not valid.


### PR DESCRIPTION
## Proposed release notes

- Allow `SignatureVerificationAlgorithm` to state FIPS status