### PR TITLE
docs: add mention of no Clone on private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ The [rustls-pemfile](https://docs.rs/rustls-pemfile) crate can be used to parse 
 
 This crate does not provide any functionality for creating new certificates or keys. However,
 the [rcgen](https://docs.rs/rcgen) crate can be used to create new certificates and keys.
+
+## Cloning private keys
+
+This crate intentionally **does not** implement `Clone` on private key types in
+order to minimize the exposure of private key data in memory.
+
+Since these types are immutable, if you find you're self wanting to clone them
+it may be better to consider wrapping the `PrivateKeyDer<'_>` in a [`Rc`]` or
+[`Arc`].
+
+[`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
+[`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,18 @@
 //!
 //! This crate does not provide any functionality for creating new certificates or keys. However,
 //! the [rcgen](https://docs.rs/rcgen) crate can be used to create new certificates and keys.
+//!
+//! ## Cloning private keys
+//!
+//! This crate intentionally **does not** implement `Clone` on private key types in
+//! order to minimize the exposure of private key data in memory.
+//!
+//! Since these types are immutable, if you find you're self wanting to clone them
+//! it may be better to consider wrapping the `PrivateKeyDer<'_>` in a [`Rc`]` or
+//! [`Arc`].
+//!
+//! [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
+//! [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(unreachable_pub, clippy::use_self)]


### PR DESCRIPTION
This comes up with some frequency and since it's a deliberate choice I think it makes sense to call out in the README and in lib.rs's rustdoc header.