### PR TITLE
Supply `web-time::SystemTime` for wasm32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,36 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+  wasm_build:
+    name: Build wasm32
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: wasm32 build (debug; default features)
+        run: cargo build --target wasm32-unknown-unknown --lib
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: wasm32 build (debug; all features)
+        run: cargo build --target wasm32-unknown-unknown --lib --all-features
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: wasm32 build (debug; no default features)
+        run: cargo build --target wasm32-unknown-unknown --lib --no-default-features
+        env:
+          RUST_BACKTRACE: 1
+
   msrv:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["network-programming", "data-structures", "cryptography"]
 default = ["alloc"]
 alloc = []
 std = ["alloc"]
+web = ["web-time"]
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+web-time = { version = "1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This should be the last piece of logic required for [*rustls* to support WebAssembly](https://github.com/rustls/rustls/issues/808).

`UnixTime::now()` is called for certificate verification in *rustls*. `std::time::SystemTime` is unavailable in wasm32-unknown-unknown, so calling `UnixTime::now()` would panic before this change. [`web-time`](https://github.com/daxpedda/web-time) appears to be a sufficient `std::time` replacement for browser environments. 

Regarding tests, I don't see any calls to `UnixTime::now()` in this crate, so It doesn't seem like testing against a wasm32 would prevent regressions that existing tests would. I'm still happy to set up wasm-bindgen-test if the maintainers would like to see those tests and run them and ci. Perhaps wasm32 tests make sense further up the stack in `rustls` where certificate verification happens and `UnixTime::now()` is called.

I did manually test a rustls connection from wasm32 using this change, however.

I plan to use this to make an https tunnel through a websocket connection in the browser
