### PR TITLE
Cargo: version 1.2.0 -> 1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This branch bumps the crate version from 1.2.0 to 1.3.0 to prepare for a release with https://github.com/rustls/pki-types/pull/33 included.

## Proposed release notes

* Adds `CertificateSigningRequestDer` to represent a DER encoded Certificate Signing Request (CSR) as specified in RFC 2986.