### PR TITLE
Prepare 1.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
# Release notes
- Bug fix: correct type names in `Debug` output for `PrivateSec1KeyDer` and `PrivatePkcs8KeyDer` types.