### PR TITLE
Cargo: version 1.3.1 -> 1.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Changelog: https://github.com/rustls/pki-types/compare/ffc074a1be42dcb298017cc175a7c5aa0c1591fa..637734886154f03a2e857650053170d5898a4124

## Proposed release notes:

* Adds `PrivateKeyDer::TryFrom` for `&[u8]` and `Vec<u8>` to map DER PKCS8, PKCS1, and SEC1 inputs to the correct `PrivateKeyDer` variant.
* Adds optional `web` feature to facilitate using `web-time` to support the `wasm32-unknown-unknown` target.
