### PR TITLE
Cargo: version 1.4.0 -> 1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
# Proposed release notes

* Relaxes `PrivateKeyDer::TryFrom` PKCS8 heuristic to accept [RFC 5958](https://www.rfc-editor.org/rfc/rfc5958) encodings using Version v2.