### PR TITLE
add EchConfigListBytes for encrypted client hello configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - stable
           - beta
           - nightly
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         # but only stable on macos/windows (slower platforms)
         include:
           - os: macos-latest
@@ -57,7 +57,7 @@ jobs:
 
   wasm_build:
     name: Build wasm32
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,14 +249,14 @@ impl PrivatePkcs1KeyDer<'_> {
 
 impl<'a> From<&'a [u8]> for PrivatePkcs1KeyDer<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        Self(Der(DerInner::Borrowed(slice)))
+        Self(Der(BytesInner::Borrowed(slice)))
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<'a> From<Vec<u8>> for PrivatePkcs1KeyDer<'a> {
     fn from(vec: Vec<u8>) -> Self {
-        Self(Der(DerInner::Owned(vec)))
+        Self(Der(BytesInner::Owned(vec)))
     }
 }
 
@@ -291,14 +291,14 @@ impl PrivateSec1KeyDer<'_> {
 
 impl<'a> From<&'a [u8]> for PrivateSec1KeyDer<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        Self(Der(DerInner::Borrowed(slice)))
+        Self(Der(BytesInner::Borrowed(slice)))
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<'a> From<Vec<u8>> for PrivateSec1KeyDer<'a> {
     fn from(vec: Vec<u8>) -> Self {
-        Self(Der(DerInner::Owned(vec)))
+        Self(Der(BytesInner::Owned(vec)))
     }
 }
 
@@ -333,14 +333,14 @@ impl PrivatePkcs8KeyDer<'_> {
 
 impl<'a> From<&'a [u8]> for PrivatePkcs8KeyDer<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        Self(Der(DerInner::Borrowed(slice)))
+        Self(Der(BytesInner::Borrowed(slice)))
     }
 }
 
 #[cfg(feature = "alloc")]
 impl<'a> From<Vec<u8>> for PrivatePkcs8KeyDer<'a> {
     fn from(vec: Vec<u8>) -> Self {
-        Self(Der(DerInner::Owned(vec)))
+        Self(Der(BytesInner::Owned(vec)))
     }
 }
 
@@ -658,12 +658,12 @@ impl UnixTime {
 /// the data is owned (by a `Vec<u8>`) or borrowed (by a `&[u8]`). Support for the owned
 /// variant is only available when the `alloc` feature is enabled.
 #[derive(Clone)]
-pub struct Der<'a>(DerInner<'a>);
+pub struct Der<'a>(BytesInner<'a>);
 
 impl<'a> Der<'a> {
     /// A const constructor to create a `Der` from a borrowed slice
     pub const fn from_slice(der: &'a [u8]) -> Self {
-        Self(DerInner::Borrowed(der))
+        Self(BytesInner::Borrowed(der))
     }
 }
 
@@ -671,8 +671,8 @@ impl AsRef<[u8]> for Der<'_> {
     fn as_ref(&self) -> &[u8] {
         match &self.0 {
             #[cfg(feature = "alloc")]
-            DerInner::Owned(vec) => vec.as_ref(),
-            DerInner::Borrowed(slice) => slice,
+            BytesInner::Owned(vec) => vec.as_ref(),
+            BytesInner::Borrowed(slice) => slice,
         }
     }
 }
@@ -687,14 +687,14 @@ impl Deref for Der<'_> {
 
 impl<'a> From<&'a [u8]> for Der<'a> {
     fn from(slice: &'a [u8]) -> Self {
-        Self(DerInner::Borrowed(slice))
+        Self(BytesInner::Borrowed(slice))
     }
 }
 
 #[cfg(feature = "alloc")]
 impl From<Vec<u8>> for Der<'static> {
     fn from(vec: Vec<u8>) -> Self {
-        Self(DerInner::Owned(vec))
+        Self(BytesInner::Owned(vec))
     }
 }
 
@@ -713,16 +713,16 @@ impl PartialEq for Der<'_> {
 impl Eq for Der<'_> {}
 
 #[derive(Clone)]
-enum DerInner<'a> {
+enum BytesInner<'a> {
     #[cfg(feature = "alloc")]
     Owned(Vec<u8>),
     Borrowed(&'a [u8]),
 }
 
 #[cfg(feature = "alloc")]
-impl DerInner<'_> {
-    fn into_owned(self) -> DerInner<'static> {
-        DerInner::Owned(match self {
+impl BytesInner<'_> {
+    fn into_owned(self) -> BytesInner<'static> {
+        BytesInner::Owned(match self {
             Self::Owned(vec) => vec,
             Self::Borrowed(slice) => slice.to_vec(),
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,6 +500,64 @@ impl CertificateDer<'_> {
     }
 }
 
+/// A TLS-encoded Encrypted Client Hello (ECH) configuration list (`ECHConfigList`); as specified in
+/// [draft-ietf-tls-esni-18 §4](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-4)
+#[derive(Clone)]
+pub struct EchConfigListBytes<'a>(BytesInner<'a>);
+
+impl EchConfigListBytes<'_> {
+    /// Converts this config into its owned variant, unfreezing borrowed content (if any)
+    #[cfg(feature = "alloc")]
+    pub fn into_owned(self) -> EchConfigListBytes<'static> {
+        EchConfigListBytes(self.0.into_owned())
+    }
+}
+
+impl fmt::Debug for EchConfigListBytes<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        hex(f, self.as_ref())
+    }
+}
+
+impl PartialEq for EchConfigListBytes<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl Eq for EchConfigListBytes<'_> {}
+
+impl AsRef<[u8]> for EchConfigListBytes<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            #[cfg(feature = "alloc")]
+            BytesInner::Owned(vec) => vec.as_ref(),
+            BytesInner::Borrowed(slice) => slice,
+        }
+    }
+}
+
+impl Deref for EchConfigListBytes<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for EchConfigListBytes<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(BytesInner::Borrowed(slice))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for EchConfigListBytes<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(BytesInner::Owned(vec))
+    }
+}
+
 /// An abstract signature verification algorithm.
 ///
 /// One of these is needed per supported pair of public key type (identified


### PR DESCRIPTION
### lib: DerInner -> BytesInner
The crate-internal `DerInner` type is really a `Cow`-like type for generic bytes. The nature of those bytes is indicated by the pub wrapper type holding the `DerInner`.

With that in mind we can re-use it for other non-DER types (e.g. ECH configs) but first need to rename the type to `BytesInner` since it is no longer DER in all cases.

### EchConfigListBytes for encrypted client hello configs

Raw ECH config lists are likely to be shared between Rustls and other crates (e.g. they may be read from `rustls-pemfile` and `.pem` inputs for server configuration, or they may be fetched from DNS using DNS-over-HTTPS using `hickory-dns` for client config).

This commit introduces a `EchConfigListBytes` type, wrapping `BytesInner`, that allows representing a borrowed or owned raw TLS encoded ECH config list, corresponding to the `ECHConfigList` type specified in TLS presentation language in [draft-ietf-tls-esni-18 §4](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-4). This type can be used between crates to maintain typed context for the bytes throughout. 
