### PR TITLE
Add SubjectPublicKeyInfo DER newtype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,6 +500,45 @@ impl CertificateDer<'_> {
     }
 }
 
+/// A DER-encoded SubjectPublicKeyInfo (SPKI), as specified in RFC 5280.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubjectPublicKeyInfo<'a>(Der<'a>);
+
+impl AsRef<[u8]> for SubjectPublicKeyInfo<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Deref for SubjectPublicKeyInfo<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl<'a> From<&'a [u8]> for SubjectPublicKeyInfo<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self(Der::from(slice))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> From<Vec<u8>> for SubjectPublicKeyInfo<'a> {
+    fn from(vec: Vec<u8>) -> Self {
+        Self(Der::from(vec))
+    }
+}
+
+impl SubjectPublicKeyInfo<'_> {
+    /// Converts this SubjectPublicKeyInfo into its owned variant, unfreezing borrowed content (if any)
+    #[cfg(feature = "alloc")]
+    pub fn into_owned(self) -> SubjectPublicKeyInfo<'static> {
+        SubjectPublicKeyInfo(Der(self.0 .0.into_owned()))
+    }
+}
+
 /// A TLS-encoded Encrypted Client Hello (ECH) configuration list (`ECHConfigList`); as specified in
 /// [draft-ietf-tls-esni-18 §4](https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-18#section-4)
 #[derive(Clone, Eq, PartialEq)]


### PR DESCRIPTION
This PR adds a new `pub struct SubjectPublicKeyInfo<'a>(Der<'a>);` type that represents an X.509 certificate's SubjectPublicKeyInfo (also known as an SPKI) as specified in RFC 5280.

I've also added a few `impl`s that mirror what exists for other `Der` newtypes, like `CertificateDer`:
* `AsRef<[u8]>`
* `Deref`
* `From<&'a [u8]>`
* `From<Vec<u8>>`
* `pub fn into_owned(self)`

The motivation behind this is to make it possible to verify consistency for public and private keys (https://github.com/rustls/rustls/issues/1918) —which can be accomplished by comparing SPKI values. CC @cpu btw.