### PR TITLE
add `const`-friendly `CertificateDer::from_slice`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ use std::time::SystemTime;
 use web_time::SystemTime;
 
 mod server_name;
+
 pub use server_name::{
     AddrParseError, DnsName, InvalidDnsNameError, IpAddr, Ipv4Addr, Ipv6Addr, ServerName,
 };
@@ -464,6 +465,13 @@ impl<'a> From<Vec<u8>> for CertificateSigningRequestDer<'a> {
 /// crate documentation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CertificateDer<'a>(Der<'a>);
+
+impl<'a> CertificateDer<'a> {
+    /// A const constructor to create a `CertificateDer` from a slice of DER.
+    pub const fn from_slice(bytes: &'a [u8]) -> Self {
+        Self(Der::from_slice(bytes))
+    }
+}
 
 impl AsRef<[u8]> for CertificateDer<'_> {
     fn as_ref(&self) -> &[u8] {


### PR DESCRIPTION
In `webpki-roots` we want to be able to codegen constant `CertificateDer` entries to support the use-case where trusted CA roots in full self-signed certificate form (as opposed to the minimal `webpki` `TrustAnchor` representation) are required, for example when working with a platform verifier that consumes x509 trust anchors (See https://github.com/rustls/webpki-roots/pull/75).

While there _is_ a `const` friendly way to create `pki_types::Der` with [`Der::from_slice()`](https://docs.rs/rustls-pki-types/latest/rustls_pki_types/struct.Der.html#method.from_slice) there's presently no `const` friendly way to create a `CertificateDer` in a similar manner. This branch adds `const CertificateDer::from_slice()` for this purpose. We skip requiring the `Der::from_slice()` and accept a `&[u8]` directly since the `CertificateDer` name already emphasizes the expected format and there's limited value in making callers jump through the extra `Der::from_slice()` hoop.

There are other types that wrap `Der<'_>` (e.g. the `PrivateKeyDer` variants, `CertificateRevocationListDer`, etc) but for now I've omitted adding similar `from_slice()` const constructors for these types until there's a concrete need in-hand.
