### PR TITLE
ci: cancel in-progress GH runs for same PR || ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '0 21 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build + test


### PR DESCRIPTION
If you're pushing new work it's generally not useful to have CI churning on the old work. Cancel it and get cooking on the new stuff ASAP. See [github docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-concurrency-groups) for more information. 

h/t https://github.com/rustls/rustls/pull/2197