### PR TITLE
Add support for the zeroize crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,12 @@ categories = ["network-programming", "data-structures", "cryptography"]
 
 [features]
 default = ["alloc"]
-alloc = []
+alloc = ["dep:zeroize"]
 std = ["alloc"]
 web = ["web-time"]
+
+[dependencies]
+zeroize = { version = "1", optional = true }
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dev-dependencies]
 crabgrind = "=0.1.9" # compatible with valgrind package on GHA ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,17 @@ pub enum PrivateKeyDer<'a> {
     Pkcs8(PrivatePkcs8KeyDer<'a>),
 }
 
+#[cfg(feature = "alloc")]
+impl zeroize::Zeroize for PrivateKeyDer<'static> {
+    fn zeroize(&mut self) {
+        match self {
+            Self::Pkcs1(key) => key.zeroize(),
+            Self::Sec1(key) => key.zeroize(),
+            Self::Pkcs8(key) => key.zeroize(),
+        }
+    }
+}
+
 impl PrivateKeyDer<'_> {
     /// Clone the private key to a `'static` value
     #[cfg(feature = "alloc")]
@@ -314,6 +325,13 @@ impl PrivatePkcs1KeyDer<'_> {
 }
 
 #[cfg(feature = "alloc")]
+impl zeroize::Zeroize for PrivatePkcs1KeyDer<'static> {
+    fn zeroize(&mut self) {
+        self.0 .0.zeroize()
+    }
+}
+
+#[cfg(feature = "alloc")]
 impl PemObjectFilter for PrivatePkcs1KeyDer<'static> {
     const KIND: SectionKind = SectionKind::RsaPrivateKey;
 }
@@ -370,6 +388,13 @@ impl PrivateSec1KeyDer<'_> {
     /// Yield the DER-encoded bytes of the private key
     pub fn secret_sec1_der(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl zeroize::Zeroize for PrivateSec1KeyDer<'static> {
+    fn zeroize(&mut self) {
+        self.0 .0.zeroize()
     }
 }
 
@@ -431,6 +456,13 @@ impl PrivatePkcs8KeyDer<'_> {
     /// Yield the DER-encoded bytes of the private key
     pub fn secret_pkcs8_der(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl zeroize::Zeroize for PrivatePkcs8KeyDer<'static> {
+    fn zeroize(&mut self) {
+        self.0 .0.zeroize()
     }
 }
 
@@ -999,6 +1031,16 @@ impl BytesInner<'_> {
             Self::Owned(vec) => vec,
             Self::Borrowed(slice) => slice.to_vec(),
         })
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl zeroize::Zeroize for BytesInner<'static> {
+    fn zeroize(&mut self) {
+        match self {
+            BytesInner::Owned(vec) => vec.zeroize(),
+            BytesInner::Borrowed(_) => (),
+        }
     }
 }
 


### PR DESCRIPTION
With a previous version of rustls, we were using [zeroize](https://lib.rs/crates/zeroize) to ensure that private keys were destroyed in memory once we were no longer using them. This PR adds a `zeroize` feature flag which enables support for the `zeroize` crate, implementing zeroization logic for `PrivateKeyDer<'static>` where the underlying data is `BytesInner::Owned`.

~If the underlying data is borrowed (i.e. `&'static [u8]`), attempting to zeroize this will (in debug mode) panic since there is nothing we can do to zeroize the data. This shouldn't be a problem since zeroization is opt-in from the consumer, as well as the fact that there is no good reason I can think of why someone would want to store a private key in a `static` or `Box::leak` such data when they can easily store it as a vector.~ If the underlying data is borrowed, this will do nothing as there is nothing the code can usefully do at this point (and it's highly unlikely anyone will end up in such a situation themselves).

I have added some tests for this feature to check that it panics/does not panic under the appropriate conditions. I've not tested for the actual zeroization as I don't want to be testing the zeroize crate itself.