### PR TITLE
v0.12.0, add `AcmeRenewalInfoCertIdentifier`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -969,6 +969,41 @@ impl UnixTime {
     }
 }
 
+/// A unique certificate identifier used for Automated Certificate Management Environment (ACME)
+/// renewal information (ARI)
+///
+/// This type can be constructed with information extracted from an X.509 certificate in order
+/// to identify it uniquely for a [RFC 8555] ACME order replacing it. For this purpose the
+/// `AcmeRenewalInfoCertIdentifier.authority_key_identifier()` and
+/// `AcmeRenewalInfoCertIdentifier.serial()` data must be BASE64 URL encoded and used to construct
+/// a URL.
+///
+/// See [draft-ietf-acme-ari-07 Section 4.1] for more information.
+///
+/// [RFC 8555]: <https://datatracker.ietf.org/doc/html/rfc8555>
+/// [draft-ietf-acme-ari-07 Section 4.1]: <https://www.ietf.org/archive/id/draft-ietf-acme-ari-07.html#section-4.1>
+#[derive(Clone, Eq, PartialEq)]
+pub struct AcmeRenewalInfoCertIdentifier<'a> {
+    /// The identified certificate's authority key identifier (AKI) extension's DER encoded ASN.1
+    /// octet string value
+    pub authority_key_identifier: Der<'a>,
+
+    /// The identified certificate's DER encoded ASN.1 serial number
+    pub serial: Der<'a>,
+}
+
+impl AcmeRenewalInfoCertIdentifier<'_> {
+    /// Converts this `AcmeRenewalInfoCertIdentifier` into its owned variant, unfreezing borrowed
+    /// content (if any)
+    #[cfg(feature = "alloc")]
+    pub fn into_owned(self) -> AcmeRenewalInfoCertIdentifier<'static> {
+        AcmeRenewalInfoCertIdentifier {
+            authority_key_identifier: Der(self.authority_key_identifier.0.into_owned()),
+            serial: Der(self.serial.0.into_owned()),
+        }
+    }
+}
+
 /// DER-encoded data, either owned or borrowed
 ///
 /// This wrapper type is used to represent DER-encoded data in a way that is agnostic to whether


### PR DESCRIPTION
**Note to reviewers: Opened as a draft while we look at the end-to-end integration in https://github.com/djc/instant-acme/pull/85**

Adds a new `AcmeRenewalInfoCertIdentifier` struct that holds two `Der` fields that can be used to uniquely identify a certificate.

The contained data is necessary to implement an extension to ACME/RFC-8555, [ACME Renewal Information (ARI)](  https://www.ietf.org/archive/id/draft-ietf-acme-ari-07.html).

For the purposes of ARI the end-state of this structure is a BASE64 URL-safe encoded URL used to identify the certificate when replacing it with a new order. Since `pki-types` only offers an internal BASE64 _decoder_ this task is left to consumers to implement with their b64 lib of choice.

See the [Let's Encrypt support announcement](https://letsencrypt.org/2023/03/23/improving-resliiency-and-reliability-with-ari/) for more information on the general utility of ARI.

### Suggested release notes

* Adds a new `AcmeRenewalInfoCertIdentifier` struct that holds two `Der` fields that can be used to uniquely identify a certificate for the purposes of [ACME automated renewal information (ARI)](https://www.ietf.org/archive/id/draft-ietf-acme-ari-07.html).