### PR TITLE
Mark all possible functions const

### DIFF
--- a/src/base64.rs
+++ b/src/base64.rs
@@ -203,7 +203,7 @@ impl CodePoint {
         )
     }
 
-    fn decode_public(a: u8) -> Self {
+    const fn decode_public(a: u8) -> Self {
         const TABLE: [CodePoint; 256] = [
             // 0x00..0x0f
             CodePoint::INVALID,
@@ -502,13 +502,13 @@ fn u8_less_than(a: u8, b: u8) -> u8 {
 }
 
 /// Returns 0xff if a == b, 0 otherwise.
-fn u8_equals(a: u8, b: u8) -> u8 {
+const fn u8_equals(a: u8, b: u8) -> u8 {
     let diff = a ^ b;
     u8_nonzero(diff)
 }
 
 /// Returns 0xff if a != 0, 0 otherwise.
-fn u8_nonzero(x: u8) -> u8 {
+const fn u8_nonzero(x: u8) -> u8 {
     u8_broadcast8(!x & x.wrapping_sub(1))
 }
 
@@ -516,7 +516,7 @@ fn u8_nonzero(x: u8) -> u8 {
 ///
 /// In other words, if the top bit of `x` is set,
 /// returns 0xff else 0x00.
-fn u8_broadcast8(x: u8) -> u8 {
+const fn u8_broadcast8(x: u8) -> u8 {
     let msb = x >> 7;
     0u8.wrapping_sub(msb)
 }
@@ -525,7 +525,7 @@ fn u8_broadcast8(x: u8) -> u8 {
 ///
 /// In other words, if the top bit of `x` is set,
 /// returns 0xff else 0x00.
-fn u8_broadcast16(x: u16) -> u8 {
+const fn u8_broadcast16(x: u16) -> u8 {
     let msb = x >> 15;
     0u8.wrapping_sub(msb as u8)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,12 +959,12 @@ impl UnixTime {
     /// Convert a `Duration` since the start of 1970 to a `UnixTime`
     ///
     /// The `duration` must be relative to the Unix epoch.
-    pub fn since_unix_epoch(duration: Duration) -> Self {
+    pub const fn since_unix_epoch(duration: Duration) -> Self {
         Self(duration.as_secs())
     }
 
     /// Number of seconds since the Unix epoch
-    pub fn as_secs(&self) -> u64 {
+    pub const fn as_secs(&self) -> u64 {
         self.0
     }
 }

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -371,7 +371,7 @@ pub enum SectionKind {
 }
 
 impl SectionKind {
-    fn secret(&self) -> bool {
+    const fn secret(&self) -> bool {
         match self {
             Self::RsaPrivateKey | Self::PrivateKey | Self::EcPrivateKey => true,
             Self::Certificate | Self::PublicKey | Self::Crl | Self::Csr | Self::EchConfigList => {

--- a/src/server_name.rs
+++ b/src/server_name.rs
@@ -542,7 +542,7 @@ mod parser {
     }
 
     impl<'a> Parser<'a> {
-        pub(super) fn new(input: &'a [u8]) -> Self {
+        pub(super) const fn new(input: &'a [u8]) -> Self {
             Parser { state: input }
         }
 


### PR DESCRIPTION
Did this at the start of march and then forgot about it.

My ultimate goal was to be able to to write `const SOMETHING: UnixTime = UnixTime::since_unix_epoch(...)` which is not a strong motivation. But AIUI this is free, and mostly mechanical.

(Can't enable `clippy::missing_const_for_fn` which points out these changes, as it doesn't respect MSRV.)