### PR TITLE
Add `From<DnsName<'a>>` for `ServerName<'a>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1068,7 +1068,7 @@ fn hex<'a>(f: &mut fmt::Formatter<'_>, payload: impl IntoIterator<Item = &'a u8>
         if i == 0 {
             write!(f, "0x")?;
         }
-        write!(f, "{:02x}", b)?;
+        write!(f, "{b:02x}")?;
     }
     Ok(())
 }
@@ -1080,13 +1080,13 @@ mod tests {
     #[test]
     fn der_debug() {
         let der = Der::from_slice(&[0x01, 0x02, 0x03]);
-        assert_eq!(format!("{:?}", der), "0x010203");
+        assert_eq!(format!("{der:?}"), "0x010203");
     }
 
     #[test]
     fn alg_id_debug() {
         let alg_id = AlgorithmIdentifier::from_slice(&[0x01, 0x02, 0x03]);
-        assert_eq!(format!("{:?}", alg_id), "0x010203");
+        assert_eq!(format!("{alg_id:?}"), "0x010203");
     }
 
     #[test]

--- a/src/server_name.rs
+++ b/src/server_name.rs
@@ -292,9 +292,9 @@ impl Hash for DnsNameInner<'_> {
 impl fmt::Debug for DnsNameInner<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Borrowed(s) => f.write_fmt(format_args!("{:?}", s)),
+            Self::Borrowed(s) => f.write_fmt(format_args!("{s:?}")),
             #[cfg(feature = "alloc")]
-            Self::Owned(s) => f.write_fmt(format_args!("{:?}", s)),
+            Self::Owned(s) => f.write_fmt(format_args!("{s:?}")),
         }
     }
 }
@@ -858,7 +858,7 @@ mod tests {
     fn test_validation() {
         for (input, expected) in TESTS {
             #[cfg(feature = "std")]
-            println!("test: {:?} expected valid? {:?}", input, expected);
+            println!("test: {input:?} expected valid? {expected:?}");
             let name_ref = DnsName::try_from(*input);
             assert_eq!(*expected, name_ref.is_ok());
             let name = DnsName::try_from(input.to_string());
@@ -869,20 +869,20 @@ mod tests {
     #[cfg(feature = "alloc")]
     #[test]
     fn error_is_debug() {
-        assert_eq!(format!("{:?}", InvalidDnsNameError), "InvalidDnsNameError");
+        assert_eq!(format!("{InvalidDnsNameError:?}"), "InvalidDnsNameError");
     }
 
     #[cfg(feature = "alloc")]
     #[test]
     fn error_is_display() {
-        assert_eq!(format!("{}", InvalidDnsNameError), "invalid dns name");
+        assert_eq!(format!("{InvalidDnsNameError}"), "invalid dns name");
     }
 
     #[cfg(feature = "alloc")]
     #[test]
     fn dns_name_is_debug() {
         let example = DnsName::try_from("example.com".to_string()).unwrap();
-        assert_eq!(format!("{:?}", example), "DnsName(\"example.com\")");
+        assert_eq!(format!("{example:?}"), "DnsName(\"example.com\")");
     }
 
     #[cfg(feature = "alloc")]

--- a/src/server_name.rs
+++ b/src/server_name.rs
@@ -166,6 +166,12 @@ impl From<std::net::Ipv6Addr> for ServerName<'_> {
     }
 }
 
+impl<'a> From<DnsName<'a>> for ServerName<'a> {
+    fn from(dns_name: DnsName<'a>) -> Self {
+        Self::DnsName(dns_name)
+    }
+}
+
 /// A type which encapsulates a string (borrowed or owned) that is a syntactically valid DNS name.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DnsName<'a>(DnsNameInner<'a>);

--- a/tests/dns_name.rs
+++ b/tests/dns_name.rs
@@ -401,8 +401,7 @@ fn dns_name_ref_try_from_ascii_test() {
         assert_eq!(
             DnsName::try_from(s).is_ok(),
             is_valid,
-            "DnsNameRef::try_from_ascii_str failed for \"{:?}\"",
-            s
+            "DnsNameRef::try_from_ascii_str failed for \"{s:?}\""
         );
     }
 }


### PR DESCRIPTION
When using `DnsName` with `rustls`, they are several places where I need the conversion to a `ServerName`.

This PR adds a `From<DnsName<'a>>` for `ServerName<'a>` which IMHO is nicer to use than `ServerName::DnsName(..)` because we can just do `into()`