### PR TITLE
pem: avoid some allocations

### DIFF
--- a/src/pem.rs
+++ b/src/pem.rs
@@ -53,10 +53,9 @@ pub trait PemObject: Sized {
     fn pem_file_iter(
         file_name: impl AsRef<std::path::Path>,
     ) -> Result<ReadIter<io::BufReader<File>, Self>, Error> {
-        Ok(ReadIter::<_, Self> {
-            rd: io::BufReader::new(File::open(file_name).map_err(Error::Io)?),
-            _ty: PhantomData,
-        })
+        Ok(ReadIter::new(io::BufReader::new(
+            File::open(file_name).map_err(Error::Io)?,
+        )))
     }
 
     /// Decode the first section of this type from PEM read from an [`io::Read`].
@@ -70,10 +69,7 @@ pub trait PemObject: Sized {
     /// Iterate over all sections of this type from PEM present in an [`io::Read`].
     #[cfg(feature = "std")]
     fn pem_reader_iter<R: std::io::Read>(rd: R) -> ReadIter<io::BufReader<R>, Self> {
-        ReadIter::<_, Self> {
-            rd: io::BufReader::new(rd),
-            _ty: PhantomData,
-        }
+        ReadIter::new(io::BufReader::new(rd))
     }
 
     /// Conversion from a PEM [`SectionKind`] and body data.

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -27,10 +27,7 @@ pub trait PemObject: Sized {
     /// Iterate over all sections of this type from PEM contained in
     /// a byte slice.
     fn pem_slice_iter(pem: &[u8]) -> SliceIter<'_, Self> {
-        SliceIter {
-            current: pem,
-            _ty: PhantomData,
-        }
+        SliceIter::new(pem)
     }
 
     /// Decode the first section of this type from the PEM contents of the named file.


### PR DESCRIPTION
+57 lines so it's not free, but IMO the complexity isn't much worse, by virtue of using more descriptive types/functions and pushing complexity to the edges.

What do you think?

@cpu want to run this through your test setup?