### PR TITLE
Add From<[u8; 4]> for Ipv4Addr

### DIFF
--- a/src/server_name.rs
+++ b/src/server_name.rs
@@ -446,6 +446,12 @@ impl From<std::net::Ipv6Addr> for IpAddr {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Ipv4Addr([u8; 4]);
 
+impl From<[u8; 4]> for Ipv4Addr {
+    fn from(value: [u8; 4]) -> Self {
+        Self(value)
+    }
+}
+
 impl TryFrom<&str> for Ipv4Addr {
     type Error = AddrParseError;
 


### PR DESCRIPTION
Currently, the only way to create `server_name::Ipv4Addr` in `no_std` world is to parse it from string. This is somewhat suboptimal. This PR adds `impl From<[u8; 4]> for Ipv4Addr`, to parallel the already existing impl for `Ipv6Addr`.