### PR TITLE
Remove mention of rustls-pemfile from docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 //! This crate provides types for representing X.509 certificates, keys and other types as
 //! commonly used in the rustls ecosystem. It is intended to be used by crates that need to work
 //! with such X.509 types, such as [rustls](https://crates.io/crates/rustls),
-//! [rustls-webpki](https://crates.io/crates/rustls-webpki),
-//! [rustls-pemfile](https://crates.io/crates/rustls-pemfile), and others.
+//! [rustls-webpki](https://crates.io/crates/rustls-webpki), and others.
 //!
 //! Some of these crates used to define their own trivial wrappers around DER-encoded bytes.
 //! However, in order to avoid inconvenient dependency edges, these were all disconnected. By


### PR DESCRIPTION
This is not present in the README either and the link in lib.rs leads to a crate belonging to a repository that has already been archived.

Linking to `rustls-pemfile` after https://github.com/rustls/pemfile/issues/61 feels incorrect