### PR TITLE
pem: error for sections that are too large

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "crabgrind",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -331,10 +331,15 @@ fn read(
 
     if section.is_some() {
         b64buf.extend(line);
+        if b64buf.len() > MAX_PEM_SECTION_SIZE {
+            return Err(Error::SectionTooLarge);
+        }
     }
 
     Ok(ControlFlow::Continue(()))
 }
+
+const MAX_PEM_SECTION_SIZE: usize = 64 * 1024 * 1024;
 
 enum SectionLabel {
     Known(SectionKind),
@@ -493,6 +498,9 @@ pub enum Error {
 
     /// No items found of desired type
     NoItemsFound,
+
+    /// PEM section exceeds maximum allowed size of 64 MB
+    SectionTooLarge,
 }
 
 impl fmt::Display for Error {
@@ -508,6 +516,7 @@ impl fmt::Display for Error {
             #[cfg(feature = "std")]
             Self::Io(e) => write!(f, "I/O error: {e}"),
             Self::NoItemsFound => write!(f, "no items found"),
+            Self::SectionTooLarge => write!(f, "PEM section exceeds maximum allowed size of 10 MB"),
         }
     }
 }

--- a/tests/pem.rs
+++ b/tests/pem.rs
@@ -352,3 +352,44 @@ impl Read for ErrorReader {
         Err(io::Error::new(io::ErrorKind::Other, "read error"))
     }
 }
+
+/// Reproduction for <https://github.com/rustls/pki-types/issues/105>.
+///
+/// We should stop reading if a PEM section is too long.
+#[test]
+fn section_too_large() {
+    let reader = UnboundedReader {
+        header: b"-----BEGIN CERTIFICATE-----\n",
+        read: 0,
+    };
+
+    let mut buf_reader = io::BufReader::new(reader);
+    let result = pem::from_buf(&mut buf_reader);
+    assert!(matches!(result, Err(pem::Error::SectionTooLarge)));
+    let reader = buf_reader.into_inner();
+    assert!(reader.read < 68_000_000, "{}", reader.read);
+}
+
+struct UnboundedReader {
+    header: &'static [u8],
+    read: usize,
+}
+
+impl Read for UnboundedReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if !self.header.is_empty() {
+            let n = self.header.len().min(buf.len());
+            buf[..n].copy_from_slice(&self.header[..n]);
+            self.header = &self.header[n..];
+            self.read += n;
+            return Ok(n);
+        }
+
+        // Emit a base64-like line (76 chars + newline, standard PEM width)
+        let line = b"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB\n";
+        let n = line.len().min(buf.len());
+        buf[..n].copy_from_slice(&line[..n]);
+        self.read += n;
+        Ok(n)
+    }
+}


### PR DESCRIPTION
Fixes #105.

First thought 64 kB might be enough (see also rustls' `CERTIFICATE_MAX_SIZE_LIMIT`), but I think CRLs might be a good chunk larger for large CAs, so maybe start with 10 MB?

```rust
/// A single recognised section in a PEM file.
#[non_exhaustive]
#[derive(Clone, Copy, Debug, PartialEq)]
pub enum SectionKind {
    /// A DER-encoded x509 certificate.
    ///
    /// Appears as "CERTIFICATE" in PEM files.
    Certificate,

    /// A DER-encoded Subject Public Key Info; as specified in RFC 7468.
    ///
    /// Appears as "PUBLIC KEY" in PEM files.
    PublicKey,

    /// A DER-encoded plaintext RSA private key; as specified in PKCS #1/RFC 3447
    ///
    /// Appears as "RSA PRIVATE KEY" in PEM files.
    RsaPrivateKey,

    /// A DER-encoded plaintext private key; as specified in PKCS #8/RFC 5958
    ///
    /// Appears as "PRIVATE KEY" in PEM files.
    PrivateKey,

    /// A Sec1-encoded plaintext private key; as specified in RFC 5915
    ///
    /// Appears as "EC PRIVATE KEY" in PEM files.
    EcPrivateKey,

    /// A Certificate Revocation List; as specified in RFC 5280
    ///
    /// Appears as "X509 CRL" in PEM files.
    Crl,

    /// A Certificate Signing Request; as specified in RFC 2986
    ///
    /// Appears as "CERTIFICATE REQUEST" in PEM files.
    Csr,

    /// An EchConfigList structure, as specified in
    /// <https://www.ietf.org/archive/id/draft-farrell-tls-pemesni-05.html>.
    ///
    /// Appears as "ECHCONFIG" in PEM files.
    EchConfigList,
}
```