### PR TITLE
1.15.0: ensure `FipsStatus::Certified` is usable 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 dependencies = [
  "crabgrind",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 edition = "2021"
 rust-version = "1.60"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1097,6 +1097,16 @@ pub enum FipsStatus {
     },
 }
 
+impl FipsStatus {
+    /// Construct a [`FipsStatus::Certified`].
+    ///
+    /// The argument should be a name, number or URL referencing the FIPS certificate.
+    /// This is for human presentation purposes, it is not for automated use.
+    pub const fn certified(certificate: &'static str) -> Self {
+        Self::Certified { certificate }
+    }
+}
+
 // Format an iterator of u8 into a hex string
 fn hex<'a>(f: &mut fmt::Formatter<'_>, payload: impl IntoIterator<Item = &'a u8>) -> fmt::Result {
     for (i, b) in payload.into_iter().enumerate() {
@@ -1122,6 +1132,12 @@ mod tests {
     fn alg_id_debug() {
         let alg_id = AlgorithmIdentifier::from_slice(&[0x01, 0x02, 0x03]);
         assert_eq!(format!("{alg_id:?}"), "0x010203");
+    }
+
+    #[test]
+    fn fips_status_debug() {
+        let fips = FipsStatus::certified("hello");
+        assert_eq!(format!("{fips:?}"), "Certified { certificate: \"hello\" }");
     }
 
     #[test]


### PR DESCRIPTION
(another option here is to remove the `#[non_exhaustive]` from the variant. This choice allows for items for the variant data to be added in the future, with the restriction that they must have some sensible value for default that can be used by the constructor fn.)