### PR TITLE
server_name: tweak branch order for performance

### DIFF
--- a/src/server_name.rs
+++ b/src/server_name.rs
@@ -346,6 +346,13 @@ const fn validate(input: &[u8]) -> Result<(), InvalidDnsNameError> {
         };
 
         match ch {
+            Some(b'a'..=b'z' | b'A'..=b'Z' | b'_') => state = LabelState::HasLetter,
+            Some(b'0'..=b'9') => {
+                state = match state {
+                    LabelState::Start | LabelState::AllNumeric => LabelState::AllNumeric,
+                    LabelState::HasLetter | LabelState::EndsInHyphen => LabelState::HasLetter,
+                }
+            }
             Some(b'.') | None => {
                 let len = idx - start;
                 if len == 0 || len > MAX_LABEL_LENGTH || matches!(state, LabelState::EndsInHyphen) {
@@ -363,20 +370,11 @@ const fn validate(input: &[u8]) -> Result<(), InvalidDnsNameError> {
                 state = LabelState::Start;
                 continue;
             }
-            Some(ch) => match ch {
-                b'0'..=b'9' => {
-                    state = match state {
-                        LabelState::Start | LabelState::AllNumeric => LabelState::AllNumeric,
-                        LabelState::HasLetter | LabelState::EndsInHyphen => LabelState::HasLetter,
-                    }
-                }
-                b'a'..=b'z' | b'A'..=b'Z' | b'_' => state = LabelState::HasLetter,
-                b'-' => match idx == start {
-                    true => return Err(InvalidDnsNameError),
-                    false => state = LabelState::EndsInHyphen,
-                },
-                _ => return Err(InvalidDnsNameError),
+            Some(b'-') => match idx == start {
+                true => return Err(InvalidDnsNameError),
+                false => state = LabelState::EndsInHyphen,
             },
+            _ => return Err(InvalidDnsNameError),
         }
 
         idx += 1;


### PR DESCRIPTION
I was playing a bit with the layout of the core loop, and this seems like a nice improvement:

```
Benchmarking dns_name/typical: Collecting 100 samples in estimated 5.0004 s 
dns_name/typical        time:   [112.08 ns 112.43 ns 113.02 ns]
                        change: [−22.891% −22.334% −21.810%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
Benchmarking dns_name/ip_like_rejected: Collecting 100 samples in estimated 
dns_name/ip_like_rejected
                        time:   [39.069 ns 39.130 ns 39.190 ns]
                        change: [+26.328% +29.896% +35.307%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
Benchmarking dns_name/max_length: Collecting 100 samples in estimated 5.0000
dns_name/max_length     time:   [132.06 ns 133.17 ns 134.80 ns]
                        change: [−25.399% −24.763% −24.139%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
```

This seems like a good trade?

(I experimented with a few other ways to order the branches but this seems optimal.)